### PR TITLE
Remove overlay on hover that prevents first touch event on ios

### DIFF
--- a/frontend/src/components/browse-list-item.tsx
+++ b/frontend/src/components/browse-list-item.tsx
@@ -12,12 +12,6 @@ export function BrowseListItem({ item, clickHandler }: BrowseListItemProps) {
     "block group flex items-center px-4 h-16 hover:bg-primary-lightest cursor-pointer text-left";
   const placeholderIcon = item.upnpclass === "item" ? IconTrack : IconContainer;
   const img = item.image ? item.image : placeholderIcon;
-  const overlay =
-    item.upnpclass === "item" ? (
-      <div className="flex justify-center items-center absolute opacity-0 group-hover:opacity-70 m-1 rounded-xl h-14 w-14 bg-gray-800 text-white font-semibold">
-        <img src={PlayIcon} className="h-10 w-10" />
-      </div>
-    ) : null;
   return (
     <li
       onClick={() => {
@@ -32,7 +26,6 @@ export function BrowseListItem({ item, clickHandler }: BrowseListItemProps) {
         alt="album art"
         className="h-14 w-14 m-1 rounded-xl object-scale-down"
       />
-      {overlay}
       {item.title}
     </li>
   );


### PR DESCRIPTION
While there are workarounds to get this working with the overlay, the click-to-play-overlay-indicator itself is not the best design idea, there should be other ways to solve this

Fixes #162